### PR TITLE
chore: updated oh-package.json name error

### DIFF
--- a/harmony/qr_decode_image_camera/oh-package.json5
+++ b/harmony/qr_decode_image_camera/oh-package.json5
@@ -1,5 +1,5 @@
 {
-  "name": "@react-native-oh-tpl/qr_decode_image_camera",
+  "name": "@react-native-oh-tpl/react-native-qr-decode-image-camera",
   "version": "1.0.0-0.0.5",
   "description": "Please describe the basic information.",
   "main": "Index.ets",


### PR DESCRIPTION
chore: updated oh-package.json name error
修复了oh-package.json name字段错误导致依赖导入不成功的问题